### PR TITLE
string.h?

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ include os.mk
 include tcsip.mk
 
 RE_CFLAGS = -DHAVE_INTTYPES_H -DHAVE_STDBOOL_H \
-    -DHAVE_INET6 -DHAVE_GAI_STRERROR -DRELEASE
+    -DHAVE_INET6 -DHAVE_GAI_STRERROR -DRELEASE -D_XOPEN_SOURCE -D_DEFAULT_SOURCE
 
 INCL = -Ideps/include/ -I./src -I./src/util -I../srtp/include/ -I../srtp/crypto/include/ \
    -I../opus/include/ -I../speex/include  -Ig711 -I./src/rehttp/

--- a/src/tcsip/tcmedia.c
+++ b/src/tcsip/tcmedia.c
@@ -1,5 +1,6 @@
 #include <srtp/srtp.h>
 #include <sys/time.h>
+#include <string.h>
 
 #include "re.h"
 #include "jitter/ajitter.h"

--- a/src/tcsip/tcmessage.c
+++ b/src/tcsip/tcmessage.c
@@ -177,7 +177,7 @@ static int msend(struct tcmessages *tcmsg, struct sip_addr *to, struct mbuf *dat
 
     tm = gmtime(&tv.tv_sec);
     strftime(dt, sizeof dt , "Date: %a, %d %b %Y %H:%M:%S", tm);
-    snprintf(date, sizeof date, "%s.%06u GMT\r\n", dt, tv.tv_usec);
+    snprintf(date, sizeof date, "%s.%06lu GMT\r\n", dt, tv.tv_usec);
 
     err = sip_drequestf(&req, tcmsg->sip, true, "MESSAGE", dlg,
             0, NULL, message_sent, message_response, ctx,

--- a/src/util/ctime.c
+++ b/src/util/ctime.c
@@ -30,7 +30,7 @@ bool find_date(const struct sip_hdr *hdr, const struct sip_msg *msg, void *arg)
     } else {
         ret = strptime(tmp.p, "%a, %d %b %Y %H:%M:%S.", &tm);
         if(ret) {
-            sscanf(ret, "%06u GMT", &tv->tv_usec);
+            sscanf(ret, "%06lu GMT", &tv->tv_usec);
         }
     }
 


### PR DESCRIPTION
 ‰ make
[ -d build-Linux-x86_64/src/tcsip ] || mkdir -p build-Linux-x86_64/src/tcsip
cc -std=gnu99 -Werror src/tcsip/tcmedia.c -o build-Linux-x86_64/src/tcsip/tcmedia.o -c -Ideps/include/ -I./src -I./src/util -I../srtp/include/ -I../srtp/crypto/include/ -I../opus/include/ -I../speex/include  -Ig711 -I./src/rehttp/ -Ideps/Linux-x86_64//srtp -Ideps/Linux-x86_64//speex  -DHAVE_INTTYPES_H -DHAVE_STDBOOL_H -DHAVE_INET6 -DHAVE_GAI_STRERROR -DRELEASE -fPIC -O0 -g
src/tcsip/tcmedia.c: В функции «sdp_crypto»:
src/tcsip/tcmedia.c:86:5: ошибка: неявная декларация функции «strlen» [-Werror=implicit-function-declaration]
     re_regex(value, strlen(value), "[0-9]+ [a-zA-Z0-9_]+ [a-zA-Z]+:[A-Za-z0-9+/]+",
     ^
src/tcsip/tcmedia.c:86:21: ошибка: несовместимая неявная декларация внутренней функции «strlen» [-Werror]
     re_regex(value, strlen(value), "[0-9]+ [a-zA-Z0-9_]+ [a-zA-Z]+:[A-Za-z0-9+/]+",
                     ^
src/tcsip/tcmedia.c: В функции «tcmedia_set_format»:
src/tcsip/tcmedia.c:454:5: ошибка: неявная декларация функции «strcmp» [-Werror=implicit-function-declaration]
     if(!strcmp(fmt_name, "speex"))
     ^
cc1: all warnings being treated as errors
make: **\* [build-Linux-x86_64/src/tcsip/tcmedia.o] Ошибка 1
